### PR TITLE
Remove all pagination from Thoughts pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,6 @@ layout: default # the layout HTML to use
 title: Page 1 # the title of this page
 order: 3 # the number of this page in the navigation bar (you're essentially setting what order the navigation bar's pages should be in)
 permalink: /page/1 # the static permalink that this page should have
-pagination: # this is for the pagination gem (see more on pagination: https://github.com/sverrirs/jekyll-paginate-v2)
-  enabled: true
 ---
 ```
 

--- a/_config.yml
+++ b/_config.yml
@@ -39,19 +39,3 @@ collections:
   thoughts:
     output: true
     permalink: /thought/:path
-
-# autopages:
-#   enabled: true
-#   collections:
-#     enabled: true
-#     permalink: /thoughts
-
-# pagination:
-#   enabled: true
-#   per_page: 3
-#   sort_field: date
-#   sort_reverse: true
-#   permalink: /:num
-#   trail:
-#     before: 2
-#     after: 2

--- a/_layouts/thoughts.html
+++ b/_layouts/thoughts.html
@@ -2,12 +2,6 @@
 layout: default
 ---
 
-<!-- <style>
-  ul.pager { text-align: center; list-style: none; }
-  ul.pager li {display: inline;border: 1px solid black; padding: 10px; margin: 5px;}
-  .selected{ background-color: magenta; }
-</style> -->
-
 {% unless page.tag == "all" %}
   <div class="row" style="display: flex">
     {% include thoughts_sidebar.html %}
@@ -62,67 +56,3 @@ layout: default
     </div>
   </div>
 {% endunless %}
-
-<!-- {% if paginator.total_pages > 1 %}
-  <ul>
-    {% if paginator.previous_page %}
-      <li>
-        <a href="{{ paginator.previous_page_path | prepend: site.baseurl }}">
-          Newer
-        </a>
-      </li>
-    {% endif %}
-    {% if paginator.next_page %}
-      <li>
-        <a href="{{ paginator.next_page_path | prepend: site.baseurl }}">
-          Older
-        </a>
-      </li>
-    {% endif %}
-
-    {% if paginator.total_pages > 1 %}
-      <ul class="pager">
-        {% if paginator.first_page %}
-          <li class="previous">
-            <a href="{{ paginator.first_page_path | prepend: site.baseurl | replace: "//", "/" }}">
-              First
-            </a>
-          </li>
-        {% endif %}
-
-      {% if paginator.previous_page %}
-        <li class="previous">
-          <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: "//", "/" }}">
-            &larr; Newer Posts
-          </a>
-        </li>
-      {% endif %}
-
-      {% if paginator.page_trail %}
-        {% for trail in paginator.page_trail %}
-          <li {% if page.url == trail.path %}class="selected"{% endif %}>
-            <a href="{{ trail.path | prepend: site.baseurl | replace: "//", "/" }}" title="{{trail.title}}">
-              {{ trail.num }}
-            </a>
-          </li>
-        {% endfor %}
-      {% endif %}
-
-      {% if paginator.next_page %}
-        <li class="next">
-          <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: "//", "/" }}">
-            Older Posts &rarr;
-          </a>
-        </li>
-      {% endif %}
-
-      {% if paginator.last_page %}
-        <li class="previous">
-          <a href="{{ paginator.last_page_path | prepend: site.baseurl | replace: "//", "" }}">
-            Last
-          </a>
-        </li>
-      {% endif %}
-    {% endif %}
-  </ul>
-{% endif %} -->

--- a/thoughts.md
+++ b/thoughts.md
@@ -4,12 +4,6 @@ title: Thoughts
 order: 4
 permalink: /thoughts
 tag: all
-pagination:
-  enabled: true
-  collection: thoughts
-  permalink: /:num
-  sort_field: date
-  sort_reverse: true
 ---
 
 <h1>What do I think about?</h1>


### PR DESCRIPTION
To have cleaner code in the master branch, I'm going to remove all of the signs of pagination on the Thoughts page. But, I wanted to do this as part of a pull request that I'll merge. This way, when I'm ready to begin working on pagination again, I can do the following:
* Make a new branch
* Revert this pull request: `git revert -m 1 COMMIT_SHA`
* Perfect pagination
* Make a new pull request to add pagination back in