### PR TITLE
Less hardcoding in the footer and header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,11 +15,13 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Emma's personal website
-repository: emma-sax4.github.io
-github_username: emma-sax4
 url: https://emma-sax4.github.io
 future: true
 markdown: kramdown
+
+github:
+  repository: https://github.com/emma-sax4/emma-sax4.github.io
+  owner: https://github.com/emma-sax4
 
 kramdown:
   smart_quotes: ["rdquo", "rsquo", "quot", "quot"]

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
   &copy; 2015<script>
     new Date().getFullYear()>2010&&document.write("–"+new Date().getFullYear());
   </script>
-  by Emma Sax. All rights reserved. Powered by
+  by <a href="{{ site.github.owner }}" target="_blank">Emma Sax</a>. All rights reserved. Powered by
   <a href="https://pages.github.com" target="_blank">GitHub Pages</a>. Source code on
-  <a href="https://github.com/emma-sax4/emma-sax4.github.io" target="_blank">GitHub</a>.
+  <a href="{{ site.github.repository }}" target="_blank">GitHub</a>.
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=minimum-scale">
   <link rel="shortcut icon" type="image/x-icon" href="/resources/favicon/favicon.ico">
   <title>Emma Sax | Platform Operations Engineer</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,10 +5,12 @@
 
       {% for node in sorted_pages %}
         {% if page.url == node.url or node.url contains page.collection and page.collection != null %}
-          <a class="active" href="{{ site.baseurl }}{{ node.url }}">{{node.title}}</a>
+          {% assign active = 'active' %}
         {% else %}
-          <a href="{{ site.baseurl }}{{ node.url }}">{{node.title}}</a>
+          {% assign active = nil %}
         {% endif %}
+
+        <a class="{{ active }}" href="{{ site.baseurl }}{{ node.url }}">{{node.title}}</a>
       {% endfor %}
     </nav>
   </div>


### PR DESCRIPTION
Changes:
* Link to things in the footer based on the values set in the `_config.yml`
* Only list each item in the header once (and just magically set the `active` class)
* Set mobile to default to looking like a desktop, and then offer zooming as needed