### PR TITLE
Making long links into smaller chunks so Bootstrap can wrap them properly

### DIFF
--- a/_posts/2019-09-12-adding-pagination-without-jekyll.md
+++ b/_posts/2019-09-12-adding-pagination-without-jekyll.md
@@ -40,7 +40,7 @@ I had never worked with submodules in Git before. So, I started how any develope
 After everything, I ended up having to add, remove, re-add, re-remove, and re-re-add the `primer` submodule to my Git repo in order for it to commit in the repo, show up in the directory structure, and be sitting on the same commit as my example repository 🤦🏻‍♀️. Here's a list of the resources I used to help me add the `primer` submodule:
 * <a href="https://chrisjean.com/git-submodules-adding-using-removing-and-updating/" target="_blank">chrisjean.com/git-submodules-adding-using-removing-and-updating</a>
 * <a href="https://stackoverflow.com/questions/10914022/how-do-i-check-out-a-specific-version-of-a-submodule-using-git-submodule" target="_blank">stackoverflow.com/how-do-i-check-out-a-specific-version-of-a-submodule-using-git-submodule</a>
-* <a href="https://twoguysarguing.wordpress.com/2010/11/14/tie-git-submodules-to-a-particular-commit-or-branch/" target="_blank">twoguysarguing.wordpress.com/tie-git-submodules-to-a-particular-commit-or-branch</a>
+* <a href="https://twoguysarguing.wordpress.com/2010/11/14/tie-git-submodules-to-a-particular-commit-or-branch/" target="_blank">2guysarguing.wordpress.com-/-tie-git-submodules-to-a-particular-commit-or-branch</a>
 * <a href="https://subfictional.com/fun-with-git-submodules/" target="_blank">subfictional.com/fun-with-git-submodules</a>
 * And possibly others I can't find in my browser history anymore
 

--- a/_posts/2019-09-13-hyphen-versus-em-versus-en-versus-everything-else.md
+++ b/_posts/2019-09-13-hyphen-versus-em-versus-en-versus-everything-else.md
@@ -88,6 +88,6 @@ On iPhones, press and hold the `-`, and a window will pop up that lets you selec
 
 ## References
 
-* <a href="https://getitwriteonline.com/articles/en-dashes-em-dashes/" target="_blank">getitwriteonline.com/en-dashes-em-dashes</a>
-* <a href="https://english.stackexchange.com/questions/20198/can-mean-the-same-thing-as-a-semicolon" target="_blank">english.stackexchange.com/can-mean-the-same-thing-as-a-semicolon</a>
-* <a href="https://english.stackexchange.com/questions/13855/what-do-you-call-words-that-are-separated-by-a-hyphen" target="_blank">english.stackexchange.com/what-do-you-call-words-that-are-separated-by-a-hyphen</a>
+* <a href="https://getitwriteonline.com/articles/en-dashes-em-dashes/" target="_blank">getitwriteonline.com/-en-dashes-em-dashes</a>
+* <a href="https://english.stackexchange.com/questions/20198/can-mean-the-same-thing-as-a-semicolon" target="_blank">english.stackexchange.com/-can-mean-the-same-thing-as-a-semicolon</a>
+* <a href="https://english.stackexchange.com/questions/13855/what-do-you-call-words-that-are-separated-by-a-hyphen" target="_blank">english.stackexchange.com/-what-do-you-call-words-that-are-separated-by-a-hyphen</a>

--- a/_posts/welcome-to-kenya/2019-09-16-the-game-drives.md
+++ b/_posts/welcome-to-kenya/2019-09-16-the-game-drives.md
@@ -127,13 +127,13 @@ All in all, we saw incredible animals at every location of our adventure. We met
 
 ## References
 
-* <a href="https://en.wikipedia.org/wiki/Ol_Pejeta_Conservancy" target="_blank">wikipedia.org/Ol_Pejeta_Conservancy</a>
+* <a href="https://en.wikipedia.org/wiki/Ol_Pejeta_Conservancy" target="_blank">wikipedia.org/Ol-Pejeta-Conservancy</a>
 * <a href="http://www.walkthroughindia.com/wild-world/top-12-elegant-species-of-antelopes-in-africa/" target="_blank">walkthroughindia.com/top-12-elegant-species-of-antelopes-in-africa</a>
 * <a href="https://animals.mom.me/names-african-gazelles-6565.html" target="_blank">animals.mom.me/names-african-gazelles</a>
 * <a href="https://www.olpejetaconservancy.org/" target="_blank">olpejetaconservancy.org</a>
 * <a href="https://www.olpejetaconservancy.org/wildlife/rhinos/black-rhinos/" target="_blank">olpejetaconservancy.org/black-rhinos</a>
-* <a href="https://www.olpejetaconservancy.org/wildlife/rhinos/northern-white-rhinos/" target="_blank">olpejetaconservancy.org/northern-white-rhinos</a>
-* <a href="https://www.olpejetaconservancy.org/wildlife/rhinos/southern-white-rhinos/" target="_blank">olpejetaconservancy.org/southern-white-rhinos</a>
+* <a href="https://www.olpejetaconservancy.org/wildlife/rhinos/northern-white-rhinos/" target="_blank">olpejetaconservancy.org/-northern-white-rhinos</a>
+* <a href="https://www.olpejetaconservancy.org/wildlife/rhinos/southern-white-rhinos/" target="_blank">olpejetaconservancy.org/-southern-white-rhinos</a>
 * <a href="https://en.wikipedia.org/wiki/Grant%27s_gazelle" target="_blank">wikipedia.org/grants_gazelle</a>
 * <a href="https://en.wikipedia.org/wiki/Dv%C5%AFr_Kr%C3%A1lov%C3%A9_Zoo" target="_blank">wikipedia.org/dvür_králové_zoo</a>
 * <a href="https://safaripark.cz/" target="_blank">safaripark.cz</a>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -5,18 +5,16 @@
 
 * {
   box-sizing: border-box;
-  // word-wrap: break-word;
-  // overflow-wrap: break-word;
-  // hyphens: auto;
-  // word-break: break-all;
 }
 
 html, body {
+  min-width: 320px;
   min-height: 100vh;
   width: 100vw;
   flex-direction: column;
   position: relative;
-  overflow-x: hidden;
+  overflow-x: scroll;
+  overflow-y: scroll;
 }
 
 body {
@@ -150,9 +148,9 @@ table {
 }
 
 .topnav-left {
-  margin-left: 15px;
-  margin-top: 10px;
-  margin-bottom: 8px;
+  padding-left: 15px;
+  padding-top: 15px;
+  padding-bottom: 5px;
   float: left;
 
   a {
@@ -170,7 +168,7 @@ table {
   a {
     display: inline-block;
     color: white;
-    padding-top: 15px;
+    padding-top: 20px;
     padding-right: 15px;
     padding-left: 15px;
     text-decoration: none;
@@ -353,7 +351,6 @@ table {
   }
 
   .main-content {
-    min-width: 1280px;
     max-width: 1600px;
     padding-top: 8px;
     padding-bottom: 32px;
@@ -474,37 +471,6 @@ table {
     flex: 60%;
     padding-top: 0px;
   }
-
-  .topnav a:not(:only-child) {
-    display: none;
-    font-size: 24px;
-  }
-
-  .topnav a.icon {
-    float: right;
-    display: block;
-  }
-
-  .topnav.responsive {
-    position: relative;
-    padding-bottom: 30px;
-    padding-right: 30px;
-    font-size: 24px;
-  }
-
-  .topnav.responsive .icon {
-    position: absolute;
-    right: 0;
-    top: 0;
-    padding-right: 30px;
-  }
-
-  .topnav.responsive a {
-    float: none;
-    display: block;
-    text-align: left;
-    font-size: 24px;
-  }
 }
 
 /*
@@ -523,6 +489,11 @@ table {
   .main-content {
     padding: 32px 36px;
     font-size: 18px;
+  }
+
+  pre {
+    overflow: auto;
+    width: 95vw;
   }
 
   .post-info {
@@ -560,6 +531,7 @@ table {
   }
 
   .topnav a.icon {
+    padding-top: 22px;
     float: right;
     display: block;
   }
@@ -604,6 +576,11 @@ table {
     font-size: 18px;
   }
 
+  pre {
+    overflow: auto;
+    width: 95vw;
+  }
+
   .post-info {
     flex: 20%;
     text-align: center;
@@ -637,6 +614,7 @@ table {
   }
 
   .topnav a.icon {
+    padding-top: 22px;
     float: right;
     display: block;
   }


### PR DESCRIPTION
## Changes
* ☝️Read title
* Set a minimum width on this site as 320px so after that, the page will just shrink smaller and smaller instead of looking uglier and uglier
* Add horizontal and vertical scroll
* Vertically center the navigation bar, left-hand name, and the hamburger bars in the blue/green nav bar
* Hold out longer to make the hamburger bars instead of the words in the nav bar, so more screens will see words than hamburger bars
* Have the pre-formatted code in blog posts add a handy inner-scrollbar, so that the blog post itself can continue to word wrap properly