### PR TITLE
Officially use new jekyll mentions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem 'jekyll', '~> 3.8.5'
 gem 'jekyll-default-layout', '~> 0.1.4'
-gem 'jekyll-mentions', '~> 1.5.1'
+gem 'jekyll-mentions', :git => 'https://github.com/emma-sax4/jekyll-mentions.git'
 gem 'jekyll-paginate-v2', '~> 2.0.0'
 gem 'jekyll-relative-links', '~> 0.6.1'
 gem 'jekyll-seo-tag', '~> 2.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/emma-sax4/jekyll-mentions.git
+  revision: f5cbe0096552bc26a827fc0eceecbd0e79b761ee
+  specs:
+    jekyll-mentions (1.5.1)
+      html-pipeline (~> 2.3)
+      jekyll (>= 3.7, < 5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -37,9 +45,6 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-default-layout (0.1.4)
       jekyll (~> 3.0)
-    jekyll-mentions (1.5.1)
-      html-pipeline (~> 2.3)
-      jekyll (>= 3.7, < 5.0)
     jekyll-paginate-v2 (2.0.0)
       jekyll (~> 3.0)
     jekyll-relative-links (0.6.1)
@@ -87,7 +92,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.8.5)
   jekyll-default-layout (~> 0.1.4)
-  jekyll-mentions (~> 1.5.1)
+  jekyll-mentions!
   jekyll-paginate-v2 (~> 2.0.0)
   jekyll-relative-links (~> 0.6.1)
   jekyll-seo-tag (~> 2.6.1)

--- a/_posts/2019-12-17-adding-bootstrap-to-your-static-content-site.md
+++ b/_posts/2019-12-17-adding-bootstrap-to-your-static-content-site.md
@@ -48,7 +48,7 @@ nav.navbar {
 
 Then, right away I could delete all of the old navbar CSS code! This included a solid chunk of lines!
 
-Next, I wanted to make it so the menu button (also known as a hamburger 🍔 icon) would turn into an ❌ button when the navbar expanded. This took more time, and to be honest, if not for <a href="https://github.com/brianMitchL" target="_blank">@brianMitchL</a>'s help, I may still be struggling. In order to save you from struggling, I'll give you some code:
+Next, I wanted to make it so the menu button (also known as a hamburger 🍔 icon) would turn into an ❌ button when the navbar expanded. This took more time, and to be honest, if not for @brianMitchL's help, I may still be struggling. In order to save you from struggling, I'll give you some code:
 ```
 nav.navbar {
   > .navbar-toggler {


### PR DESCRIPTION
## Changes
* Use https://github.com/emma-sax4/jekyll-mentions for `jekyll-mentions` gem instead of what's on RubyGems
* Actually utilize the gem in one of the blog posts