### PR TITLE
Use HTML to define markdown links

### DIFF
--- a/_pages/around_town.md
+++ b/_pages/around_town.md
@@ -7,8 +7,8 @@ permalink: /around-town/
 
 ## Talks
 
-* _What We Learn from Reviewing Others' Work_, DevOpsDays MSP 2019 ([slides](/assets/resources/DevOpsDays_MSP_Ignite_20190806.pdf){:target="_blank"}, [recording](https://devopsdays.org/events/2019-minneapolis/program/emma-sax/))
-* _DevOps in Education: A Virtually Non-Existent Course_, DevOpsDays MSP 2017 ([slides](/assets/resources/DevOpsDays_MSP_Ignite_20170725.pdf){:target="_blank"}, [recording](https://devopsdays.org/events/2017-minneapolis/program/emma-sax/))
+* _What We Learn from Reviewing Others' Work_, DevOpsDays MSP 2019 (<a href="/assets/resources/DevOpsDays_MSP_Ignite_20190806.pdf" target="_blank">slides</a>, [recording](https://devopsdays.org/events/2019-minneapolis/program/emma-sax/))
+* _DevOps in Education: A Virtually Non-Existent Course_, DevOpsDays MSP 2017 (<a href="/assets/resources/DevOpsDays_MSP_Ignite_20170725.pdf" target="_blank">slides</a>, [recording](https://devopsdays.org/events/2017-minneapolis/program/emma-sax/))
 
 ## Programming Competitions
 


### PR DESCRIPTION
## Changes
* Deploy markdown internal links via HTML so that these links can deploy in a new tab

Do this so that in GitHub rendered markdown, the annoying `{:target="_blank"}` doesn't show up. Just make it look like a normal link, even if it's only opening in the same tab.