### PR TITLE
Fix unintentionally changed lines

### DIFF
--- a/_includes/blog/post.html
+++ b/_includes/blog/post.html
@@ -16,7 +16,7 @@
         {% assign now = "now" | date: "%s" %}
         {% assign date = post.date | date: "%s" %}
         {% if date <= now %}
-          Published {{ post.date | date: "%B %-d, %Y" }}
+          {{ post.date | date: "%B %-d, %Y" }}
         {% else %}
           Unpublished
         {% endif %}


### PR DESCRIPTION
## Changes
Remove the `"Published"` word from listing the date of a blog post.