### PR TITLE
Attempt to deploy via Travis another time 🙄

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,32 +19,18 @@ install:
   - bundle config set without 'development'
   - bundle install
 
-jobs:
-  include:
-    - stage: Test
-      name: Jekyll Build
-      script:
-        - JEKYLL_ENV=production bundle exec jekyll build --destination ./site
-    - stage: Test
-      name: HTML Proofer
-      before_script:
-        - JEKYLL_ENV=production bundle exec jekyll build --destination ./site
-      script:
-        - htmlproofer --assume-extension --allow-hash-href --internal-domains "/emmasax4.info/" --url-ignore "/linkedin/,/digikey/" ./site
+script:
+  - JEKYLL_ENV=production bundle exec jekyll build --destination ./site
+  - htmlproofer --assume-extension --allow-hash-href --internal-domains "/emmasax4.info/" --url-ignore "/linkedin/,/digikey/" ./site
 
-    - stage: Deploy
-      if: (type NOT IN (pull_request)) AND (branch = release)
-      name: GitHub Pages
-      before_deploy:
-        - JEKYLL_ENV=production bundle exec jekyll build --destination ./site
-      deploy:
-        - provider: pages
-          email: deploy@travis-ci.org
-          name: Deployment Bot
-          target_branch: master
-          local_dir: ./site
-          token: $GITHUB_TOKEN
-          keep_history: true
-          skip_cleanup: true
-          on:
-            branch: release
+deploy:
+  provider: pages
+  email: deploy@travis-ci.org
+  name: Deployment Bot
+  target_branch: master
+  local_dir: ./site
+  token: $GITHUB_TOKEN
+  keep_history: true
+  skip_cleanup: true
+  on:
+    branch: release


### PR DESCRIPTION
## Changes
Apparently I cannot get this deployment right! But I got thinking... I'll actually end up saving a lot of time on the Travis CI builds if I don't install the gems three times. So, by putting them all into one script instead of into Stages or Jobs, I'll end up saving time. And if any of the lines break, it'll break the next part, which is necessary, too. I think I was just trying to be too fancy. I wish the builds looked as cool as with the jobs and such, but efficiency is more important than fanciness at the end of the day.

In fact on pull requests, by putting them all into one run, I'm cutting almost two minutes off the build!