### PR TITLE
Smartquotes and new icons

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -65,12 +65,12 @@ A full deployment only takes about five to ten minutes, but depending on what wa
 
 We can check periodically that all of the HTML links in this website load correctly:
 ```bash
-bundle exec jekyll build # with optional --future flag
+JEKYLL_ENV=production bundle exec jekyll build
 htmlproofer --assume-extension --allow-hash-href ./_site
 ```
 
-External links to LinkedIn typically return an error code, as explained [here](https://github.com/gjtorikian/html-proofer/issues/215). The other link that I typically see returning error codes is one to Digi-Key. I haven't quite figured out why that is.
+External links to LinkedIn typically return an error code, as explained [here](https://github.com/gjtorikian/html-proofer/issues/215). The other link that I usually see returning error codes is one to Digi-Key. I haven't quite figured out why that is.
 
-If you're in the process of creating a new blog post, then most likely (if you ran your build command with `--future`) the external link to that new blog post will fail. This makes sense—the blog post isn't live online yet, and that's what the link is checking for.
+If you're in the process of creating a new blog post, then most likely the external link to the new blog post will fail. This makes sense—the blog post isn't live online yet, and that's what the link is checking for.
 
-Travis CI also runs a special version of the HTML Proofer, which skips over all internal domains and ignores LinkedIn and Digi-Key domains.
+Travis CI also runs a version of the HTML Proofer which skips over all internal domains and ignores LinkedIn and Digi-Key domains.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ notifications:
 before_install:
   - export TZ=America/Chicago
 
+install:
+  - bundle install
+
 script:
   - JEKYLL_ENV=production bundle exec jekyll build --destination ./site
   - htmlproofer --assume-extension --allow-hash-href --internal-domains "/emmasax4.info/" --url-ignore "/linkedin/,/digikey/" ./site

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ notifications:
 before_install:
   - export TZ=America/Chicago
 
-install:
-  - bundle config set without 'development'
-  - bundle install
-
 script:
   - JEKYLL_ENV=production bundle exec jekyll build --destination ./site
   - htmlproofer --assume-extension --allow-hash-href --internal-domains "/emmasax4.info/" --url-ignore "/linkedin/,/digikey/" ./site

--- a/_config.yml
+++ b/_config.yml
@@ -83,5 +83,5 @@ feed:
     items: 5
   development:
     title: LOCAL Emma's Blog
-    url: https://127.0.0.1:4000
+    url: http://127.0.0.1:4000
     items: 5

--- a/_config.yml
+++ b/_config.yml
@@ -18,11 +18,6 @@ title: Emma Sax
 description: Emma Sax's personal website and blog. Includes information about my social media profiles, résumé, and hobbies.
 url: https://emmasax4.info
 
-future: false
-highlighter: rouge
-jekyll-mentions: https://github.com
-markdown: kramdown
-
 github:
   repo: https://github.com/emma-sax4/emma-sax4.github.io
   owner: https://github.com/emma-sax4
@@ -38,6 +33,11 @@ webmaster_verifications:
   google: v04az8eo-0UcZrWCJr7SKAvM6hw90qTCBQoKx3PlXCA
   bing: 89B2B19FF966341B78EF64EDADE6DF81
   yandex: c2741887f8c30dd1
+
+future: false
+highlighter: rouge
+jekyll-mentions: https://github.com
+markdown: kramdown
 
 disqus:
   shortname: emmasax4

--- a/_config.yml
+++ b/_config.yml
@@ -22,13 +22,6 @@ github:
   repo: https://github.com/emma-sax4/emma-sax4.github.io
   owner: https://github.com/emma-sax4
 
-kramdown:
-  smart_quotes:
-    - apos
-    - apos
-    - quot
-    - quot
-
 webmaster_verifications:
   google: v04az8eo-0UcZrWCJr7SKAvM6hw90qTCBQoKx3PlXCA
   bing: 89B2B19FF966341B78EF64EDADE6DF81

--- a/_includes/elements/email_button.html
+++ b/_includes/elements/email_button.html
@@ -1,6 +1,6 @@
 <div class="text-center link-icon-button">
   <a href="mailto:emma.sax4@gmail.com" class="btn btn-md btn-outline-secondary">
-    <i data-feather="send"></i>
+    <i data-feather="mail"></i>
     emma.sax4@gmail.com
   </a>
 </div>


### PR DESCRIPTION
## Changes
* Change the `send` icon to the `mail` icon (paper airplane to letter)
* Change the development feed URL to be `http` instead of `https`
* Make all straight quotes into smart quotes