### PR TITLE
Travis build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ notifications:
   slack:
     on_success: always
     on_failure: always
+    on_pull_requests: true
     template:
       - Repo `%{repository_slug}` *%{result}* build (<%{build_url}|#%{build_number}>)
         for commit (<%{compare_url}|%{commit}>) on branch `%{branch}`.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,8 @@ notifications:
     on_success: always
     on_failure: always
     on_pull_requests: true
-    template:
-      - Repo `%{repository_slug}` *%{result}* build (<%{build_url}|#%{build_number}>)
-        for commit (<%{compare_url}|%{commit}>) on branch `%{branch}`.
-      - 'Execution time: *%{duration}*'
-      - 'Message: %{message}'
     rooms:
-      secure: YyQu7D1XaL43GcigvjVEjx+GGfvfvPcKR87kJNVf55/X9F47M/3zNtckrvQoIu4gDdwGC/UBe/mhywpO9xUiGNaE9S/ZW9clvwE0IAleji/+YKlPJWw61P+NM8cGlffMFW5ti5SnOb1X9iPICnMGYa1kxB501iFBRp+47CUVKuqgkgiT7NJTokoytybjpy84NZtwo5xw2TmizmW2vbxsfFidWwbIIKa6BWq+7xPMukdDg9Cy6/WUfQ9iJ5WJBwVKu6VOLLSI1S0fodxHsCbFhgmQxFfjsZ67Wv66VwkTIU8T7qCvf/8kk4B8Wt+VdipQQx24pr2yfkRQC+nUG6WYTTGiBAAAh7xvmwgsfxsExjOWwO+SJItpD4HHzqcmKr7l3ECiQ1/FpOGX4tLY0Agni9diEKbe0gL/KJWgnhhQcKvRNzY13Er8Y9dQRWTLH2+94RgHL4L+F/NvYfGtfkAsO4nysM8n+eV+IGV0rMyNd3OoEdRSmLetxK9GQqNZDEGWDuETux+PGwLvurXEZ9bIH7cJXwlS5CJ0v2JnHbZPqoHphsCzcsDN3ASH48sqcAOZwjibICYAxPh7BM3HHCYi1z2EC1UsrFsx6HaCOA6/1SvuCBYOERzWhIAkvcvbAiHs0ctxxM9Bl9NrBSy5ujyEL3MfQq9HYbqlCQoZtw2oe6Y=
+      - secure: YyQu7D1XaL43GcigvjVEjx+GGfvfvPcKR87kJNVf55/X9F47M/3zNtckrvQoIu4gDdwGC/UBe/mhywpO9xUiGNaE9S/ZW9clvwE0IAleji/+YKlPJWw61P+NM8cGlffMFW5ti5SnOb1X9iPICnMGYa1kxB501iFBRp+47CUVKuqgkgiT7NJTokoytybjpy84NZtwo5xw2TmizmW2vbxsfFidWwbIIKa6BWq+7xPMukdDg9Cy6/WUfQ9iJ5WJBwVKu6VOLLSI1S0fodxHsCbFhgmQxFfjsZ67Wv66VwkTIU8T7qCvf/8kk4B8Wt+VdipQQx24pr2yfkRQC+nUG6WYTTGiBAAAh7xvmwgsfxsExjOWwO+SJItpD4HHzqcmKr7l3ECiQ1/FpOGX4tLY0Agni9diEKbe0gL/KJWgnhhQcKvRNzY13Er8Y9dQRWTLH2+94RgHL4L+F/NvYfGtfkAsO4nysM8n+eV+IGV0rMyNd3OoEdRSmLetxK9GQqNZDEGWDuETux+PGwLvurXEZ9bIH7cJXwlS5CJ0v2JnHbZPqoHphsCzcsDN3ASH48sqcAOZwjibICYAxPh7BM3HHCYi1z2EC1UsrFsx6HaCOA6/1SvuCBYOERzWhIAkvcvbAiHs0ctxxM9Bl9NrBSy5ujyEL3MfQq9HYbqlCQoZtw2oe6Y=
 
 install:
   - bundle install
@@ -33,8 +28,8 @@ deploy:
   email: deploy@travis-ci.org
   name: Deployment Bot
   target_branch: master
-  local_dir: "./site"
-  token: "$GITHUB_TOKEN"
+  local_dir: ./site
+  token: $GITHUB_TOKEN
   keep_history: true
   edge: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ install:
 
 script:
   - JEKYLL_ENV=production bundle exec jekyll build --destination ./site
+
+after_script:
   - htmlproofer --assume-extension --allow-hash-href --internal-domains "/emmasax4.info/" --url-ignore "/linkedin/,/digikey/" ./site
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ branches:
     - release
 
 notifications:
-  email:
-    on_success: never
+  slack:
+    on_success: always
     on_failure: always
-    recipients:
-      - emma.sax4@gmail.com
+    rooms:
+      - veaPpsL4FrPhhHAaHf4j77PpJsBz3R33K1cVDVz/TtBvbBojfWNHNwIcQFzRdmhX0zVv8PA7AdNxM0VZYbt/A9ebzk/Ws6WbyNLUyraazGsj13uUyPp9zpmAt0czh1U0RfoJ8bDR6ySveRtUdTLPIEqa/LCAK0nfK3pqeff1hr2g2T6WJf6YecKQGv9uC8fMWJeNxRcIvApT4K3xXfiizWlLkVZpAhT242364xWcOMe4onpAmdzUPTdvE8iji7Zhct7XLLGKMorIoD6j9R/TI3rf60K1VBZT9CDeTkdyHC692WnQBh2b4n82Ps7G1Ys5WX7GiCCbITakhrzIXDpFljzXrAvIP0Dhyk2faKut6jh5eMkqHAKdCQfhu/dPK8tlS91PfokzwBWBCGeJEYljTCRBewv3r2QQ8Tu3iFAuozcz+LYXf2yhDjQoSyykw2+mmj1vEGJyKpQwI7y+fcVkpWnCKTlMLIOCROCJrOJmQGGx2I6FPGhMXDv0y3HkytECj67Jon1/Lcsph73A0Z1FAjvui5aZMsLe37e0uwmAbxhEjPTXsxuZLo8jhskBTrtwZdDEEu79H5c+8M2vV8uFE0dolI6FIHVg+E/fhxVBE2T9pRnmwPl/V5YSgXYqQBy2/3HMQ751IPomxsjhpiXeyzHFf8Z4RjOkhdUZkcoyvC4=
 
 install:
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 script:
   - JEKYLL_ENV=production bundle exec jekyll build --destination ./site
 
-after_script:
+after_success:
   - htmlproofer --assume-extension --allow-hash-href --internal-domains "/emmasax4.info/" --url-ignore "/linkedin/,/digikey/" ./site
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ branches:
 notifications:
   email: false
   slack:
-    on_success: always
-    on_failure: always
-    on_pull_requests: true
     rooms:
       - secure: YyQu7D1XaL43GcigvjVEjx+GGfvfvPcKR87kJNVf55/X9F47M/3zNtckrvQoIu4gDdwGC/UBe/mhywpO9xUiGNaE9S/ZW9clvwE0IAleji/+YKlPJWw61P+NM8cGlffMFW5ti5SnOb1X9iPICnMGYa1kxB501iFBRp+47CUVKuqgkgiT7NJTokoytybjpy84NZtwo5xw2TmizmW2vbxsfFidWwbIIKa6BWq+7xPMukdDg9Cy6/WUfQ9iJ5WJBwVKu6VOLLSI1S0fodxHsCbFhgmQxFfjsZ67Wv66VwkTIU8T7qCvf/8kk4B8Wt+VdipQQx24pr2yfkRQC+nUG6WYTTGiBAAAh7xvmwgsfxsExjOWwO+SJItpD4HHzqcmKr7l3ECiQ1/FpOGX4tLY0Agni9diEKbe0gL/KJWgnhhQcKvRNzY13Er8Y9dQRWTLH2+94RgHL4L+F/NvYfGtfkAsO4nysM8n+eV+IGV0rMyNd3OoEdRSmLetxK9GQqNZDEGWDuETux+PGwLvurXEZ9bIH7cJXwlS5CJ0v2JnHbZPqoHphsCzcsDN3ASH48sqcAOZwjibICYAxPh7BM3HHCYi1z2EC1UsrFsx6HaCOA6/1SvuCBYOERzWhIAkvcvbAiHs0ctxxM9Bl9NrBSy5ujyEL3MfQq9HYbqlCQoZtw2oe6Y=
+    on_success: always
+    on_failure: always
 
 install:
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,15 @@ script:
   - JEKYLL_ENV=production bundle exec jekyll build --destination ./site
 
 after_script:
-  - htmlproofer --assume-extension --allow-hash-href --internal-domains "/emmasax4.info/"
-  --url-ignore "/linkedin/,/digikey/" ./site
+  - htmlproofer --assume-extension --allow-hash-href --internal-domains "/emmasax4.info/" --url-ignore "/linkedin/,/digikey/" ./site
 
 deploy:
   provider: pages
   email: deploy@travis-ci.org
   name: Deployment Bot
   target_branch: master
-  local_dir: "./site"
-  token: "$GITHUB_TOKEN"
+  local_dir: ./site
+  token: $GITHUB_TOKEN
   keep_history: true
   edge: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,15 @@ branches:
     - release
 
 notifications:
+  email: false
   slack:
     on_success: always
     on_failure: always
     secure: HYwSCisi7UHQcQbBgv/YjjlfMvjmjacuLy9XSChssUIZ9Ypr2vkdeCCb80JZpH1ZIG9uUlmphQhH4h+MWGH8lniXbaachBCcvna1ogmrf/+iXABOhVlSxR5vOy7+AHb68OetStrdbkS9EcGFfchmV3l2R7+xmC20KVwSIivWU+FIsVNT7uU7GFs30ClUujDfbfe3s7hIGjhjX+X23BjbfPUjFS/2Kr1LFYu5ZvXYbdLrWMOi9CkU4XasJjsyPU618fRsTmaHqmbnZL5MVHBEIulqbYY2pwgfHPabrZqLq7+oOzzcH35jNjoc6a+IBt0dfbSf+bIttUKl+gHLgReoolPgyBdyR71KbiBYdF7ngwHQzXpKaIlxsc0ZXg4bT0v3gfF7acbYk/81bs/WGsB3YivyJ+oheysNrfwuTY4qJ1Xgf/rB/vidfysoxkzU8RTGfbGMV/cYzh9CVwfsfzhO5xYnw+NLP4851ZkQiFFGO7DapMc7HqbVLiAw010Mvr6E3UP5dAI4utScpCCJcMbRYhLeDnfhBGk8NOdDDZW/0FVbBda4yJhkE+WxbAwoiveWPO98mAQjE/NrGEdF3QWA7PMsT6jZ8USCSfiu7QwKfN8Yf/ltxi8ubHSdEf5IJUfTlzQQb94ZdT6W1tweEnfFn0LhSxzkG4QT7My67KXgchI=
+    template:
+      - "Repo `%{repository_slug}` *%{result}* build (<%{build_url}|#%{build_number}>) for commit (<%{compare_url}|%{commit}>) on branch `%{branch}`."
+      - "Execution time: *%{duration}*"
+      - "Message: %{message}"
 
 install:
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ notifications:
   slack:
     on_success: always
     on_failure: always
-    rooms:
-      - veaPpsL4FrPhhHAaHf4j77PpJsBz3R33K1cVDVz/TtBvbBojfWNHNwIcQFzRdmhX0zVv8PA7AdNxM0VZYbt/A9ebzk/Ws6WbyNLUyraazGsj13uUyPp9zpmAt0czh1U0RfoJ8bDR6ySveRtUdTLPIEqa/LCAK0nfK3pqeff1hr2g2T6WJf6YecKQGv9uC8fMWJeNxRcIvApT4K3xXfiizWlLkVZpAhT242364xWcOMe4onpAmdzUPTdvE8iji7Zhct7XLLGKMorIoD6j9R/TI3rf60K1VBZT9CDeTkdyHC692WnQBh2b4n82Ps7G1Ys5WX7GiCCbITakhrzIXDpFljzXrAvIP0Dhyk2faKut6jh5eMkqHAKdCQfhu/dPK8tlS91PfokzwBWBCGeJEYljTCRBewv3r2QQ8Tu3iFAuozcz+LYXf2yhDjQoSyykw2+mmj1vEGJyKpQwI7y+fcVkpWnCKTlMLIOCROCJrOJmQGGx2I6FPGhMXDv0y3HkytECj67Jon1/Lcsph73A0Z1FAjvui5aZMsLe37e0uwmAbxhEjPTXsxuZLo8jhskBTrtwZdDEEu79H5c+8M2vV8uFE0dolI6FIHVg+E/fhxVBE2T9pRnmwPl/V5YSgXYqQBy2/3HMQ751IPomxsjhpiXeyzHFf8Z4RjOkhdUZkcoyvC4=
+    secure: HYwSCisi7UHQcQbBgv/YjjlfMvjmjacuLy9XSChssUIZ9Ypr2vkdeCCb80JZpH1ZIG9uUlmphQhH4h+MWGH8lniXbaachBCcvna1ogmrf/+iXABOhVlSxR5vOy7+AHb68OetStrdbkS9EcGFfchmV3l2R7+xmC20KVwSIivWU+FIsVNT7uU7GFs30ClUujDfbfe3s7hIGjhjX+X23BjbfPUjFS/2Kr1LFYu5ZvXYbdLrWMOi9CkU4XasJjsyPU618fRsTmaHqmbnZL5MVHBEIulqbYY2pwgfHPabrZqLq7+oOzzcH35jNjoc6a+IBt0dfbSf+bIttUKl+gHLgReoolPgyBdyR71KbiBYdF7ngwHQzXpKaIlxsc0ZXg4bT0v3gfF7acbYk/81bs/WGsB3YivyJ+oheysNrfwuTY4qJ1Xgf/rB/vidfysoxkzU8RTGfbGMV/cYzh9CVwfsfzhO5xYnw+NLP4851ZkQiFFGO7DapMc7HqbVLiAw010Mvr6E3UP5dAI4utScpCCJcMbRYhLeDnfhBGk8NOdDDZW/0FVbBda4yJhkE+WxbAwoiveWPO98mAQjE/NrGEdF3QWA7PMsT6jZ8USCSfiu7QwKfN8Yf/ltxi8ubHSdEf5IJUfTlzQQb94ZdT6W1tweEnfFn0LhSxzkG4QT7My67KXgchI=
 
 install:
   - bundle install
@@ -19,15 +18,16 @@ script:
   - JEKYLL_ENV=production bundle exec jekyll build --destination ./site
 
 after_script:
-  - htmlproofer --assume-extension --allow-hash-href --internal-domains "/emmasax4.info/" --url-ignore "/linkedin/,/digikey/" ./site
+  - htmlproofer --assume-extension --allow-hash-href --internal-domains "/emmasax4.info/"
+  --url-ignore "/linkedin/,/digikey/" ./site
 
 deploy:
   provider: pages
   email: deploy@travis-ci.org
   name: Deployment Bot
   target_branch: master
-  local_dir: ./site
-  token: $GITHUB_TOKEN
+  local_dir: "./site"
+  token: "$GITHUB_TOKEN"
   keep_history: true
   edge: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ notifications:
   slack:
     on_success: always
     on_failure: always
-    secure: HYwSCisi7UHQcQbBgv/YjjlfMvjmjacuLy9XSChssUIZ9Ypr2vkdeCCb80JZpH1ZIG9uUlmphQhH4h+MWGH8lniXbaachBCcvna1ogmrf/+iXABOhVlSxR5vOy7+AHb68OetStrdbkS9EcGFfchmV3l2R7+xmC20KVwSIivWU+FIsVNT7uU7GFs30ClUujDfbfe3s7hIGjhjX+X23BjbfPUjFS/2Kr1LFYu5ZvXYbdLrWMOi9CkU4XasJjsyPU618fRsTmaHqmbnZL5MVHBEIulqbYY2pwgfHPabrZqLq7+oOzzcH35jNjoc6a+IBt0dfbSf+bIttUKl+gHLgReoolPgyBdyR71KbiBYdF7ngwHQzXpKaIlxsc0ZXg4bT0v3gfF7acbYk/81bs/WGsB3YivyJ+oheysNrfwuTY4qJ1Xgf/rB/vidfysoxkzU8RTGfbGMV/cYzh9CVwfsfzhO5xYnw+NLP4851ZkQiFFGO7DapMc7HqbVLiAw010Mvr6E3UP5dAI4utScpCCJcMbRYhLeDnfhBGk8NOdDDZW/0FVbBda4yJhkE+WxbAwoiveWPO98mAQjE/NrGEdF3QWA7PMsT6jZ8USCSfiu7QwKfN8Yf/ltxi8ubHSdEf5IJUfTlzQQb94ZdT6W1tweEnfFn0LhSxzkG4QT7My67KXgchI=
     template:
-      - "Repo `%{repository_slug}` *%{result}* build (<%{build_url}|#%{build_number}>) for commit (<%{compare_url}|%{commit}>) on branch `%{branch}`."
-      - "Execution time: *%{duration}*"
-      - "Message: %{message}"
+      - Repo `%{repository_slug}` *%{result}* build (<%{build_url}|#%{build_number}>)
+        for commit (<%{compare_url}|%{commit}>) on branch `%{branch}`.
+      - 'Execution time: *%{duration}*'
+      - 'Message: %{message}'
+    rooms:
+      secure: YyQu7D1XaL43GcigvjVEjx+GGfvfvPcKR87kJNVf55/X9F47M/3zNtckrvQoIu4gDdwGC/UBe/mhywpO9xUiGNaE9S/ZW9clvwE0IAleji/+YKlPJWw61P+NM8cGlffMFW5ti5SnOb1X9iPICnMGYa1kxB501iFBRp+47CUVKuqgkgiT7NJTokoytybjpy84NZtwo5xw2TmizmW2vbxsfFidWwbIIKa6BWq+7xPMukdDg9Cy6/WUfQ9iJ5WJBwVKu6VOLLSI1S0fodxHsCbFhgmQxFfjsZ67Wv66VwkTIU8T7qCvf/8kk4B8Wt+VdipQQx24pr2yfkRQC+nUG6WYTTGiBAAAh7xvmwgsfxsExjOWwO+SJItpD4HHzqcmKr7l3ECiQ1/FpOGX4tLY0Agni9diEKbe0gL/KJWgnhhQcKvRNzY13Er8Y9dQRWTLH2+94RgHL4L+F/NvYfGtfkAsO4nysM8n+eV+IGV0rMyNd3OoEdRSmLetxK9GQqNZDEGWDuETux+PGwLvurXEZ9bIH7cJXwlS5CJ0v2JnHbZPqoHphsCzcsDN3ASH48sqcAOZwjibICYAxPh7BM3HHCYi1z2EC1UsrFsx6HaCOA6/1SvuCBYOERzWhIAkvcvbAiHs0ctxxM9Bl9NrBSy5ujyEL3MfQq9HYbqlCQoZtw2oe6Y=
 
 install:
   - bundle install
@@ -30,8 +32,8 @@ deploy:
   email: deploy@travis-ci.org
   name: Deployment Bot
   target_branch: master
-  local_dir: ./site
-  token: $GITHUB_TOKEN
+  local_dir: "./site"
+  token: "$GITHUB_TOKEN"
   keep_history: true
   edge: true
   on:

--- a/_includes/blog/post.html
+++ b/_includes/blog/post.html
@@ -23,7 +23,6 @@
       </span>
     </div>
 
-
     <a href="{{ site.baseurl }}{{ post_url }}">{{ short_title }}</a>
 
     <div>

--- a/_includes/site/scripts.html
+++ b/_includes/site/scripts.html
@@ -57,7 +57,7 @@ To open an INTERNAL link in a NEW tab, write your link like this:
   openExternalLinksInNewTabs();
 </script>
 
-<script src="https://unpkg.com/feather-icons"></script>
+<script src="https://unpkg.com/feather-icons@4.25.0/dist/feather.min.js"></script>
 <script>feather.replace()</script>
 
 <script


### PR DESCRIPTION
## Changes
* Make the feather install the full URL so there are no redirect—this means that when the pages load if we inspect the network tab, we now get 200s from feather instead of 400s
* Delete extra newlines in HTML file
* Run `htmlproofer` as an `after_success` in the `.travis.yml` so it doesn't hold up deploys on `release` branch
* Notify Slack when Travis builds are done, instead of via email