### PR TITLE
Just remove travis custom messages altogether

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ notifications:
     on_success: always
     on_failure: always
     on_pull_requests: true
-    template:
-      - Build <%{build_url}|#%{build_number}> for *%{repository_slug}* `%{result}`.
-      - Commit <%{compare_url}|%{commit}>, PR <%{pull_request_url}|#%{pull_request_number}>, branch `%{branch}`.
-      - Build ran for *%{duration}*.
 
 install:
   - bundle install


### PR DESCRIPTION
## Changes
Just remove the custom templates altogether, if I can't easily distinguish between pull requests and push builds. Travis should do it nicely by itself.