### PR TITLE
Add requirement on _posts for linguist-detectable back

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.md linguist-detectable=true
 README.md linguist-detectable=false
 .github/* linguist-detectable=false
+_posts/* linguist-detectable=false


### PR DESCRIPTION
## Changes
Do not include the `_posts` directory when determining the "language" of this repository. There's too many markdown blog posts to be useful (just with the current amount of blog posts, Linguist will say that 94% of the repository is markdown, and that's not really helping anybody). This is undoing one of the files changed in #144.