### PR TITLE
Enable pagination trailing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem 'html-proofer',                '~> 3.15.1'
 gem 'jekyll',                      '~> 3.8.5'
 gem 'jekyll-default-layout',       '~> 0.1.4'
-gem 'jekyll-paginate-v2',          '~> 2.0.0'
+gem 'jekyll-paginate-v2',          '~> 3.0.0'
 gem 'jekyll-redirect-from',        '~> 0.16.0'
 gem 'jekyll-relative-links',       '~> 0.6.1'
 gem 'jekyll-time-to-read',         '~> 0.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,8 +70,8 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-default-layout (0.1.4)
       jekyll (~> 3.0)
-    jekyll-paginate-v2 (2.0.0)
-      jekyll (~> 3.0)
+    jekyll-paginate-v2 (3.0.0)
+      jekyll (>= 3.0, < 5.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-relative-links (0.6.1)
@@ -127,7 +127,7 @@ DEPENDENCIES
   jekyll (~> 3.8.5)
   jekyll-default-layout (~> 0.1.4)
   jekyll-mentions!
-  jekyll-paginate-v2 (~> 2.0.0)
+  jekyll-paginate-v2 (~> 3.0.0)
   jekyll-redirect-from (~> 0.16.0)
   jekyll-relative-links (~> 0.6.1)
   jekyll-seo-tag!

--- a/_config.yml
+++ b/_config.yml
@@ -74,8 +74,8 @@ pagination:
   sort_field: date
   sort_reverse: true
   trail:
-    before: 2
-    after: 2
+    before: 1
+    after: 1
 
 feed:
   production:

--- a/_config.yml
+++ b/_config.yml
@@ -69,7 +69,7 @@ collections:
 
 pagination:
   enabled: true
-  per_page: 10
+  per_page: 5
   limit: 0
   sort_field: date
   sort_reverse: true

--- a/_config.yml
+++ b/_config.yml
@@ -69,7 +69,7 @@ collections:
 
 pagination:
   enabled: true
-  per_page: 5
+  per_page: 10
   limit: 0
   sort_field: date
   sort_reverse: true

--- a/_includes/blog/pagination.html
+++ b/_includes/blog/pagination.html
@@ -9,11 +9,10 @@
 
     <!-- Loop through the pages -->
     {% for count in (1..paginator.total_pages) %}
+      {% assign number = count %}
       {% if count == paginator.page %}
-        {% assign number = count %}
         {% include elements/pagination/active_page.html %}
       {% else %}
-        {% assign number = count %}
         {% include elements/pagination/numbered_page.html %}
       {% endif %}
     {% endfor %}

--- a/_includes/blog/pagination.html
+++ b/_includes/blog/pagination.html
@@ -1,62 +1,28 @@
-{% if paginator.total_pages > 1 %}
-  <nav aria-label="Blog post navigation">
-    <ul class="pagination justify-content-center">
-      {% if paginator.previous_page %}
-        <li class="page-item">
-          <a class="page-link" href="{{ paginator.previous_page_path }}">
-            <i style="width: 18px; height: 18px;" data-feather="skip-back"></i>
-          </a>
-        </li>
+<nav aria-label="Blog post navigation">
+  <ul class="pagination justify-content-center">
+    <!-- Show the button to the previous page -->
+    {% if paginator.previous_page %}
+      {% include elements/pagination/previous_page.html %}
+    {% else %}
+      {% include elements/pagination/disabled_x.html %}
+    {% endif %}
+
+    <!-- Loop through the pages -->
+    {% for count in (1..paginator.total_pages) %}
+      {% if count == paginator.page %}
+        {% assign number = count %}
+        {% include elements/pagination/active_page.html %}
       {% else %}
-        <li class="page-item disabled">
-          <a class="page-link" href="#">
-            <i style="width: 18px; height: 18px;" data-feather="x-octagon"></i>
-          </a>
-        </li>
+        {% assign number = count %}
+        {% include elements/pagination/numbered_page.html %}
       {% endif %}
+    {% endfor %}
 
-      {% for count in (1..paginator.total_pages) %}
-        {% if count == paginator.page %}
-          <li class="page-item active">
-            <a class="page-link" href="#">{{ count }}</a>
-          </li>
-        {% else %}
-          {% if page.pagination.title == "Blog" %}
-            {% assign url_shortname = "/" %}
-          {% else %}
-            {% if page.pagination.tag %}
-              {% assign url_shortname = "/" | append: page.pagination.tag | append: "/" %}
-            {% else page.pagination.category %}
-              {% assign category_name = page.pagination.category | downcase | replace: " ", "-" %}
-              {% assign url_shortname = "/" | append: category_name | append: "/" %}
-            {% endif %}
-          {% endif %}
-
-          {% if count == 1 %}
-            {% assign blog_url = "/blog" | append: url_shortname %}
-          {% else %}
-            {% assign blog_url = "/blog" | append: url_shortname | append: count | append: "/" %}
-          {% endif %}
-
-          <li class="page-item">
-            <a class="page-link" href="{{ blog_url }}">{{ count }}</a>
-          </li>
-        {% endif %}
-      {% endfor %}
-
-      {% if paginator.next_page %}
-        <li class="page-item">
-          <a class="page-link" href="{{ paginator.next_page_path }}">
-            <i style="width: 18px; height: 18px;" data-feather="skip-forward"></i>
-          </a>
-        </li>
-      {% else %}
-        <li class="page-item disabled">
-          <a class="page-link" href="#">
-            <i style="width: 18px; height: 18px;" data-feather="x-octagon"></i>
-          </a>
-        </li>
-      {% endif %}
-    </ul>
-  </div>
-{% endif %}
+    <!-- Show the button to the next page -->
+    {% if paginator.next_page %}
+      {% include elements/pagination/next_page.html %}
+    {% else %}
+      {% include elements/pagination/disabled_x.html %}
+    {% endif %}
+  </ul>
+</div>

--- a/_includes/blog/pagination_trail.html
+++ b/_includes/blog/pagination_trail.html
@@ -1,5 +1,6 @@
 <nav aria-label="Blog post navigation">
   <ul class="pagination justify-content-center">
+    {% assign second_to_last = paginator.total_pages | times: 1 | minus: 1 %}
     {% assign trail_numbers = "" | split: ',' %}
     {% for trail in paginator.page_trail %}
       {% assign trail_numbers = trail_numbers | push: trail.num %}
@@ -25,17 +26,15 @@
 
     <!-- Loop through the trail -->
     {% for trail in paginator.page_trail %}
+      {% assign number = trail.num %}
       {% if trail.num == paginator.page %}
-        {% assign number = trail.num %}
         {% include elements/pagination/active_page.html %}
       {% else %}
-        {% assign number = trail.num %}
         {% include elements/pagination/numbered_page.html %}
       {% endif %}
     {% endfor %}
 
     <!-- If there's space between the trail and the last page, then show ... -->
-    {% assign second_to_last = paginator.total_pages | times: 1 | minus: 1 %}
     {% unless trail_numbers contains second_to_last %}
       {% include elements/pagination/empty_ellipsis.html %}
     {% endunless %}

--- a/_includes/blog/pagination_trail.html
+++ b/_includes/blog/pagination_trail.html
@@ -1,0 +1,56 @@
+<nav aria-label="Blog post navigation">
+  <ul class="pagination justify-content-center">
+    {% assign trail_numbers = "" | split: ',' %}
+    {% for trail in paginator.page_trail %}
+      {% assign trail_numbers = trail_numbers | push: trail.num %}
+    {% endfor %}
+
+    <!-- Show the button to the previous page -->
+    {% if paginator.previous_page %}
+      {% include elements/pagination/previous_page.html %}
+    {% else %}
+      {% include elements/pagination/disabled_x.html %}
+    {% endif %}
+
+    <!-- Always show the first page -->
+    {% unless trail_numbers contains 1 %}
+      {% assign number = 1 %}
+      {% include elements/pagination/numbered_page.html %}
+    {% endunless %}
+
+    <!-- If there's space between the trail and the first page, then show ... -->
+    {% unless trail_numbers contains 2 %}
+      {% include elements/pagination/empty_ellipsis.html %}
+    {% endunless %}
+
+    <!-- Loop through the trail -->
+    {% for trail in paginator.page_trail %}
+      {% if trail.num == paginator.page %}
+        {% assign number = trail.num %}
+        {% include elements/pagination/active_page.html %}
+      {% else %}
+        {% assign number = trail.num %}
+        {% include elements/pagination/numbered_page.html %}
+      {% endif %}
+    {% endfor %}
+
+    <!-- If there's space between the trail and the last page, then show ... -->
+    {% assign second_to_last = paginator.total_pages | times: 1 | minus: 1 %}
+    {% unless trail_numbers contains second_to_last %}
+      {% include elements/pagination/empty_ellipsis.html %}
+    {% endunless %}
+
+    <!-- Always show the last page -->
+    {% unless trail_numbers contains paginator.total_pages %}
+      {% assign number = paginator.total_pages %}
+      {% include elements/pagination/numbered_page.html %}
+    {% endunless %}
+
+    <!-- Show the button to the next page -->
+    {% if paginator.next_page %}
+      {% include elements/pagination/next_page.html %}
+    {% else %}
+      {% include elements/pagination/disabled_x.html %}
+    {% endif %}
+  </ul>
+</div>

--- a/_includes/blog/posts_list.html
+++ b/_includes/blog/posts_list.html
@@ -5,5 +5,9 @@
     {% endfor %}
   </ul>
 
-  {% include blog/pagination.html %}
+  {% if paginator.total_pages >= 9 %}
+    {% include blog/pagination_trail.html %}
+  {% elsif paginator.total_pages > 1 %}
+    {% include blog/pagination.html %}
+  {% endif %}
 </div>

--- a/_includes/blog/posts_list.html
+++ b/_includes/blog/posts_list.html
@@ -5,7 +5,7 @@
     {% endfor %}
   </ul>
 
-  {% if paginator.total_pages >= 9 %}
+  {% if paginator.total_pages >= 8 %}
     {% include blog/pagination_trail.html %}
   {% elsif paginator.total_pages > 1 %}
     {% include blog/pagination.html %}

--- a/_includes/elements/pagination/active_page.html
+++ b/_includes/elements/pagination/active_page.html
@@ -1,0 +1,3 @@
+<li class="page-item active">
+  <a class="page-link">{{ number }}</a>
+</li>

--- a/_includes/elements/pagination/disabled_x.html
+++ b/_includes/elements/pagination/disabled_x.html
@@ -1,0 +1,5 @@
+<li class="page-item disabled">
+  <a class="page-link">
+    <i style="width: 18px; height: 18px;" data-feather="x-octagon"></i>
+  </a>
+</li>

--- a/_includes/elements/pagination/empty_ellipsis.html
+++ b/_includes/elements/pagination/empty_ellipsis.html
@@ -1,0 +1,3 @@
+<li class="page-item disabled">
+  <a class="page-link">...</a>
+</li>

--- a/_includes/elements/pagination/next_page.html
+++ b/_includes/elements/pagination/next_page.html
@@ -1,0 +1,5 @@
+<li class="page-item">
+  <a class="page-link" href="{{ paginator.next_page_path }}">
+    <i style="width: 18px; height: 18px;" data-feather="skip-forward"></i>
+  </a>
+</li>

--- a/_includes/elements/pagination/numbered_page.html
+++ b/_includes/elements/pagination/numbered_page.html
@@ -1,0 +1,20 @@
+{% if page.pagination.title == "Blog" %}
+  {% assign url_shortname = "/" %}
+{% else %}
+  {% if page.pagination.tag %}
+    {% assign url_shortname = "/" | append: page.pagination.tag | append: "/" %}
+  {% else page.pagination.category %}
+    {% assign category_name = page.pagination.category | downcase | replace: " ", "-" %}
+    {% assign url_shortname = "/" | append: category_name | append: "/" %}
+  {% endif %}
+{% endif %}
+
+{% if number == 1 %}
+  {% assign blog_url = "/blog" | append: url_shortname %}
+{% else %}
+  {% assign blog_url = "/blog" | append: url_shortname | append: number | append: "/" %}
+{% endif %}
+
+<li class="page-item">
+  <a class="page-link" href="{{ blog_url }}">{{ number }}</a>
+</li>

--- a/_includes/elements/pagination/previous_page.html
+++ b/_includes/elements/pagination/previous_page.html
@@ -1,0 +1,5 @@
+<li class="page-item">
+  <a class="page-link" href="{{ paginator.previous_page_path }}">
+    <i style="width: 18px; height: 18px;" data-feather="skip-back"></i>
+  </a>
+</li>


### PR DESCRIPTION
## Changes

If there are 8 or more pages of blog posts, then automatically have them use the [`trail`](https://github.com/sverrirs/jekyll-paginate-v2/blob/master/README-GENERATOR.md#creating-pagination-trails) feature of `jekyll-paginate-v2`. The trail feature will show the `X` amount of surrounding pages to the active page in the pagination. It will also show the first page (page 1) and the last page (`paginator.total_pages`) on every paginated page. It will also show a `...` box if needed.

This is so that I don't need to worry about long paginators taking up too much space on small screens (technically at 320 pixels, the pagination bar may _still_ take up a little too much horizontal space, but I don't care too much).