### PR TITLE
All links opening in the current tab

### DIFF
--- a/js/external-links.js
+++ b/js/external-links.js
@@ -7,7 +7,7 @@ To open an INTERNAL link in a NEW tab, write your link like this:
 */
 var links = document.getElementsByTagName('a');
 
-for(counter = 0; counter < c.length; counter++) {
+for(counter = 0; counter < links.length; counter++) {
   var link = links[counter];
 
   if (link.target == '_self') {


### PR DESCRIPTION
## Changes

As of right now, all external AND internal links are opening in the current tab. This means that something about the recent changes to the `external-links.js` file is broken. When I renamed all of the variables, I guess I forgot to change this one.