### PR TITLE
Update circleci workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ workflows:
       - build_and_test_and_deploy:
           filters:
             branches:
-              ignore: [ release ]
+              ignore: [ release, master ]
   release:
     jobs:
       - build_and_test_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,24 @@ workflows:
               only: [ release ]
     triggers:
       - schedule:
-          cron: "6 * * * *" # this is midnight in CST
+          cron: "0 6 * * *" # 06:00 UTC => 00:00 CST
+          filters:
+            branches:
+              only: [ release ]
+  evening_cron:
+    jobs:
+      - build_and_test:
+          filters:
+            branches:
+              only: [ release ]
+      - deploy:
+          requires: [ build_and_test ]
+          filters:
+            branches:
+              only: [ release ]
+    triggers:
+      - schedule:
+          cron: "0 1 * * *" # 01:00 UTC => 19:00 CST
           filters:
             branches:
               only: [ release ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,10 @@ workflows:
   version: 2
   develop:
     jobs:
-      - build_and_test_and_deploy
+      - build_and_test_and_deploy:
+          filters:
+            branches:
+              ignore: [ release ]
   release:
     jobs:
       - build_and_test_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   ruby: circleci/ruby@0.1.2
   slack: circleci/slack@3.4.2
 jobs:
-  build_and_test_and_deploy:
+  build:
     working_directory: ~/emma-sax4.github.io
     docker:
       - image: circleci/ruby:2.6-node
@@ -23,6 +23,11 @@ jobs:
           key: bundler-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
+  test:
+    working_directory: ~/emma-sax4.github.io
+    docker:
+      - image: circleci/ruby:2.6-node
+    steps:
       - run:
           name: Jekyll Build
           command: JEKYLL_ENV=production bundle exec jekyll build --destination ./site
@@ -36,6 +41,11 @@ jobs:
             --url-ignore /linkedin/,/digikey/ \
             ./site \
             || echo "HTML Proofer failed. Please investigate the failures."
+  deploy:
+    working_directory: ~/emma-sax4.github.io
+    docker:
+      - image: circleci/ruby:2.6-node
+    steps:
       - deploy:
           name: Deploy to GitHub Pages
           command: |
@@ -75,19 +85,28 @@ workflows:
   version: 2
   develop:
     jobs:
-      - build_and_test_and_deploy:
+      - build:
           filters:
             branches:
               ignore: [ release, master ]
+      - test:
+          requires: [ build ]
+          filters:
+            branches:
+              ignore: [ release, master ]
+      # - build_and_test_and_deploy:
+      #     filters:
+      #       branches:
+      #         ignore: [ release, master ]
   release:
     jobs:
-      - build_and_test_and_deploy:
+      - build:
           filters:
             branches:
               only: [ release ]
   nightly_cron:
     jobs:
-      - build_and_test_and_deploy
+      - build
     triggers:
       - schedule:
           cron: "6 * * * *" # this is midnight in CST

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,9 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@0.1.2
   slack: circleci/slack@3.4.2
+
 jobs:
-  build:
+  build_and_test:
     working_directory: ~/emma-sax4.github.io
     docker:
       - image: circleci/ruby:2.6-node
@@ -23,11 +24,6 @@ jobs:
           key: bundler-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-  test:
-    working_directory: ~/emma-sax4.github.io
-    docker:
-      - image: circleci/ruby:2.6-node
-    steps:
       - run:
           name: Jekyll Build
           command: JEKYLL_ENV=production bundle exec jekyll build --destination ./site
@@ -41,11 +37,41 @@ jobs:
             --url-ignore /linkedin/,/digikey/ \
             ./site \
             || echo "HTML Proofer failed. Please investigate the failures."
+      - run:
+          name: Slack - Creating Custom Message
+          command: |
+            if [ -z $CIRCLE_PULL_REQUESTS ]; then
+              m="Build #$CIRCLE_BUILD_NUM of $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME@$CIRCLE_BRANCH by $CIRCLE_USERNAME"
+            else
+              m="Build #$CIRCLE_BUILD_NUM of $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME@$CIRCLE_BRANCH in PR $CIRCLE_PULL_REQUESTS by $CIRCLE_USERNAME"
+            fi
+            echo "export SLACK_MESSAGE='$m'" >> $BASH_ENV; source $BASH_ENV
+      - slack/status:
+          success_message: $SLACK_MESSAGE passed.
+          failure_message: $SLACK_MESSAGE failed.
+          include_job_number_field: false
+          include_project_field: false
+
   deploy:
     working_directory: ~/emma-sax4.github.io
     docker:
       - image: circleci/ruby:2.6-node
     steps:
+      - checkout
+      - run:
+          name: Configure Bundler
+          command: |
+            echo "export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d ' ')" >> $BASH_ENV; source $BASH_ENV
+            gem install bundler
+      - restore_cache:
+          key: bundler-cache-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Bundle Install
+          command: bundle install --path vendor/bundle
+      - save_cache:
+          key: bundler-cache-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
       - deploy:
           name: Deploy to GitHub Pages
           command: |
@@ -70,43 +96,44 @@ jobs:
       - run:
           name: Slack - Creating Custom Message
           command: |
-            if [ -z $CIRCLE_PULL_REQUESTS ]; then
-              m="Build #$CIRCLE_BUILD_NUM of $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME@$CIRCLE_BRANCH by $CIRCLE_USERNAME"
-            else
-              m="Build #$CIRCLE_BUILD_NUM of $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME@$CIRCLE_BRANCH in PR $CIRCLE_PULL_REQUESTS by $CIRCLE_USERNAME"
-            fi
+            m="Deploy to $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:master "
             echo "export SLACK_MESSAGE='$m'" >> $BASH_ENV; source $BASH_ENV
       - slack/status:
           success_message: $SLACK_MESSAGE passed.
           failure_message: $SLACK_MESSAGE failed.
           include_job_number_field: false
           include_project_field: false
+
 workflows:
   version: 2
   develop:
     jobs:
-      - build:
+      - build_and_test:
           filters:
             branches:
               ignore: [ release, master ]
-      - test:
-          requires: [ build ]
-          filters:
-            branches:
-              ignore: [ release, master ]
-      # - build_and_test_and_deploy:
-      #     filters:
-      #       branches:
-      #         ignore: [ release, master ]
   release:
     jobs:
-      - build:
+      - build_and_test:
+          filters:
+            branches:
+              only: [ release ]
+      - deploy:
+          requires: [ build_and_test ]
           filters:
             branches:
               only: [ release ]
   nightly_cron:
     jobs:
-      - build
+      - build_and_test:
+          filters:
+            branches:
+              only: [ release ]
+      - deploy:
+          requires: [ build_and_test ]
+          filters:
+            branches:
+              only: [ release ]
     triggers:
       - schedule:
           cron: "6 * * * *" # this is midnight in CST

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,16 +88,9 @@ jobs:
             git add -fA
             git commit -m "Deploy to emma-sax4/emma-sax4.github.io.git:master via CircleCI"
             git push origin master
-
-            echo "GitHub Pages deployed successfully."
-      - run:
-          name: Slack - Creating Custom Message
-          command: |
-            m="Deploy to $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:master "
-            echo "export SLACK_MESSAGE='$m'" >> $BASH_ENV; source $BASH_ENV
       - slack/status:
-          success_message: $SLACK_MESSAGE passed.
-          failure_message: $SLACK_MESSAGE failed.
+          success_message: GitHub Pages deployed successfully.
+          failure_message: GitHub Pages deployed erred.
           include_job_number_field: false
           include_project_field: false
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,24 +75,21 @@ jobs:
       - deploy:
           name: Deploy to GitHub Pages
           command: |
-            if [ $CIRCLE_BRANCH == "release" ]; then
-              git config user.name "$USER_NAME"
-              git config user.email "$USER_EMAIL"
+            git config user.name "$USER_NAME"
+            git config user.email "$USER_EMAIL"
 
-              git checkout master
-              git pull origin master
+            git checkout master
+            git pull origin master
 
-              find . -maxdepth 1 ! -name "site" ! -name ".git" -exec rm -rf {} \;
-              mv ./site/* .
-              rm -R ./site/
+            find . -maxdepth 1 ! -name "site" ! -name ".git" -exec rm -rf {} \;
+            mv ./site/* .
+            rm -R ./site/
 
-              git add -fA
-              git commit -m "Deploy to emma-sax4/emma-sax4.github.io.git:master via CircleCI"
-              git push origin master
-              echo "GitHub Pages deployed successfully."
-            else
-              echo "This build is for a pull request. Skipping deploy."
-            fi
+            git add -fA
+            git commit -m "Deploy to emma-sax4/emma-sax4.github.io.git:master via CircleCI"
+            git push origin master
+
+            echo "GitHub Pages deployed successfully."
       - run:
           name: Slack - Creating Custom Message
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,8 @@ jobs:
             git commit -m "Deploy to emma-sax4/emma-sax4.github.io.git:master via CircleCI"
             git push origin master
       - slack/status:
-          success_message: GitHub Pages deployed successfully.
-          failure_message: GitHub Pages deployed erred.
+          success_message: Successfully deployed to GitHub Pages.
+          failure_message: Error deploying to GitHub Pages.
           include_job_number_field: false
           include_project_field: false
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,15 +115,9 @@ workflows:
               only: [ release ]
   nightly_cron:
     jobs:
-      - build_and_test:
-          filters:
-            branches:
-              only: [ release ]
+      - build_and_test
       - deploy:
           requires: [ build_and_test ]
-          filters:
-            branches:
-              only: [ release ]
     triggers:
       - schedule:
           cron: "0 6 * * *" # 06:00 UTC => 00:00 CST
@@ -132,15 +126,9 @@ workflows:
               only: [ release ]
   evening_cron:
     jobs:
-      - build_and_test:
-          filters:
-            branches:
-              only: [ release ]
+      - build_and_test
       - deploy:
           requires: [ build_and_test ]
-          filters:
-            branches:
-              only: [ release ]
     triggers:
       - schedule:
           cron: "0 1 * * *" # 01:00 UTC => 19:00 CST


### PR DESCRIPTION
## Changes
Do not run the `develop` workflow on `release` and `master` branch. Split the deploy and the rest of the tests into two separate jobs so the deploy is never accidentally run on a pull request (aka a branch other than release).