### PR TITLE
Only set one nightly cron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,12 +97,7 @@ workflows:
     jobs: [ test-and-deploy ]
     triggers:
     - schedule:
-        cron: "0 5 * * *" # 05:00 UTC => 00:00 CDT
-        filters:
-          branches:
-            only: [ release ]
-    - schedule:
-        cron: "0 6 * * *" # 06:00 UTC => 00:00 CST
+        cron: "30 5 * * *" # 05:30 UTC => 00:30 CDT / 23:30 CST
         filters:
           branches:
             only: [ release ]


### PR DESCRIPTION
## Changes
* We only need one cron, so just split it between the two hours for CST/CDT