### PR TITLE
Blog links should always point to commits, not to the default branch

### DIFF
--- a/_posts/2019-12-29-bootstrap-css-and-icons-in-this-site.md
+++ b/_posts/2019-12-29-bootstrap-css-and-icons-in-this-site.md
@@ -34,7 +34,7 @@ This site uses [Bootstrap's buttons](https://getbootstrap.com/docs/4.0/component
 
 ## CSS
 
-Using Bootstrap for the entire layout of this website, as well as for specific elements means there's so much less CSS in this repository. I started with over 600 lines of CSS, and now I have about 220 lines. But, there are still some pieces that I've chosen to override from Bootstrap's defaults. All of my custom CSS is in [this directory](https://github.com/emma-sax4/emma-sax4.github.io/tree/release/assets/css).
+Using Bootstrap for the entire layout of this website, as well as for specific elements means there's so much less CSS in this repository. I started with over 600 lines of CSS, and now I have about 220 lines. But, there are still some pieces that I've chosen to override from Bootstrap's defaults. All of my custom CSS is in [this directory](https://github.com/emma-sax4/emma-sax4.github.io/tree/62b1cc916f71d07f5935b31ae218a0805edf56c8/assets/css).
 
 The pieces I'm overriding are:
 * Blockquotes

--- a/_posts/2019-12-29-bootstrap-css-and-icons-in-this-site.md
+++ b/_posts/2019-12-29-bootstrap-css-and-icons-in-this-site.md
@@ -77,7 +77,7 @@ Lastly, as long as these two lines are at the bottom of the file, the icons appe
 <script>feather.replace()</script>
 ```
 
-See them in action [here](https://github.com/emma-sax4/emma-sax4.github.io/blob/129867d8135a930f4d364fe026db123d655b5ca8/_includes/site/scripts.html#L3-L4.
+See them in action [here](https://github.com/emma-sax4/emma-sax4.github.io/blob/129867d8135a930f4d364fe026db123d655b5ca8/_includes/site/scripts.html#L3-L4).
 
 ## Conclusion
 

--- a/_posts/2019-12-29-bootstrap-css-and-icons-in-this-site.md
+++ b/_posts/2019-12-29-bootstrap-css-and-icons-in-this-site.md
@@ -18,19 +18,19 @@ My site is responsive because of [Bootstrap's responsive layout](https://getboot
 
 ### Pagination
 
-To make the pretty pagination bar appear on the blog pages, I use [Bootstrap's built-in pagination](https://getbootstrap.com/docs/4.0/components/pagination/) to create the CSS. Specifically, I use `disabled` and `active` states, as well as center-page alignment. See where I implement Bootstrap's pagination bar [here](https://github.com/emma-sax4/emma-sax4.github.io/blob/release/_includes/blog/pagination.html#L1-L2). For the icons, I use [Feather Icons](https://github.com/feathericons/feather).
+To make the pretty pagination bar appear on the blog pages, I use [Bootstrap's built-in pagination](https://getbootstrap.com/docs/4.0/components/pagination/) to create the CSS. Specifically, I use `disabled` and `active` states, as well as center-page alignment. See where I implement Bootstrap's pagination bar [here](https://github.com/emma-sax4/emma-sax4.github.io/blob/62b1cc916f71d07f5935b31ae218a0805edf56c8/_includes/blog/pagination.html#L1-L2). For the icons, I use [Feather Icons](https://github.com/feathericons/feather).
 
 ### Navbar
 
-The responsive navbar utilized in this site is from [Bootstrap's built-in navbar](https://getbootstrap.com/docs/4.0/components/navbar/) option. Specifically, it uses the [Navbar](https://getbootstrap.com/docs/4.0/components/navbar/#nav) which is fully responsive on smaller screens, as well as the `Primary` color scheme shown [here](https://getbootstrap.com/docs/4.0/components/navbar/#color-schemes). I do add some custom icons to the drop-down section of the responsive navbar, as well as customizing the color and the font-styles. The navbar is in action [here](https://github.com/emma-sax4/emma-sax4.github.io/blob/release/_includes/site/header.html), and [here](https://github.com/emma-sax4/emma-sax4.github.io/blob/release/assets/css/_navigation.scss) is the overriding CSS for my navbar.
+The responsive navbar utilized in this site is from [Bootstrap's built-in navbar](https://getbootstrap.com/docs/4.0/components/navbar/) option. Specifically, it uses the [Navbar](https://getbootstrap.com/docs/4.0/components/navbar/#nav) which is fully responsive on smaller screens, as well as the `Primary` color scheme shown [here](https://getbootstrap.com/docs/4.0/components/navbar/#color-schemes). I do add some custom icons to the drop-down section of the responsive navbar, as well as customizing the color and the font-styles. The navbar is in action [here](https://github.com/emma-sax4/emma-sax4.github.io/blob/62b1cc916f71d07f5935b31ae218a0805edf56c8/_includes/site/header.html), and [here](https://github.com/emma-sax4/emma-sax4.github.io/blob/1db304c1b1358bfc47f67783448807f173cb18a2/assets/css/_navigation.scss) is the overriding CSS for my navbar.
 
 ### Tables
 
-For my tables on this site, I use [Bootstrap's built-in tables](https://getbootstrap.com/docs/4.0/content/tables/), which are responsive, as long as you use `class: "table-responsive"` at the top (read more about responsive tables [here](https://getbootstrap.com/docs/4.0/content/tables/#responsive-tables)). The tables I've selected to use is described in ['Hoverable Rows'](https://getbootstrap.com/docs/4.0/content/tables/#hoverable-rows). I use the tables in [this Markdown file](https://github.com/emma-sax4/emma-sax4.github.io/blob/release/_pages/around-town.md) and in <a href="https://github.com/emma-sax4/emma-sax4.github.io/blob/release/_posts/2019-12-20-dns-domains-and-personal-websites.md" target="_blank">this Markdown file</a>. Because it's Markdown, it may be more helpful to view the 'Raw' code.
+For my tables on this site, I use [Bootstrap's built-in tables](https://getbootstrap.com/docs/4.0/content/tables/), which are responsive, as long as you use `class: "table-responsive"` at the top (read more about responsive tables [here](https://getbootstrap.com/docs/4.0/content/tables/#responsive-tables)). The tables I've selected to use is described in ['Hoverable Rows'](https://getbootstrap.com/docs/4.0/content/tables/#hoverable-rows). I use the tables in [this Markdown file](https://github.com/emma-sax4/emma-sax4.github.io/blob/62b1cc916f71d07f5935b31ae218a0805edf56c8/_pages/around-town.md#on-stage) and in [this Markdown file](https://github.com/emma-sax4/emma-sax4.github.io/blob/a7476415f32185b45321b04a7abf869d37e3e623/_posts/2019-12-20-dns-domains-and-personal-websites.md#domains). Because it's Markdown, it may be more helpful to view the 'Raw' code.
 
 ### Buttons
 
-This site uses [Bootstrap's buttons](https://getbootstrap.com/docs/4.0/components/buttons/) for all of it's button functionality (unless the button is an icon). Here's a [button that I've made](https://github.com/emma-sax4/emma-sax4.github.io/blob/release/_includes/elements/github-issue-button.html) that uses Bootstrap's design but includes a Feather Icon. I prefer the look of the [Outline buttons](https://getbootstrap.com/docs/4.0/components/buttons/#outline-buttons) more than the solid ones, but that's just my preference.
+This site uses [Bootstrap's buttons](https://getbootstrap.com/docs/4.0/components/buttons/) for all of it's button functionality (unless the button is an icon). Here's a [button that I've made](https://github.com/emma-sax4/emma-sax4.github.io/blob/62b1cc916f71d07f5935b31ae218a0805edf56c8/_includes/elements/github-issue-button.html) that uses Bootstrap's design but includes a Feather Icon. I prefer the look of the [Outline buttons](https://getbootstrap.com/docs/4.0/components/buttons/#outline-buttons) more than the solid ones, but that's just my preference.
 
 ## CSS
 
@@ -77,7 +77,7 @@ Lastly, as long as these two lines are at the bottom of the file, the icons appe
 <script>feather.replace()</script>
 ```
 
-See them in action [here](https://github.com/emma-sax4/emma-sax4.github.io/blob/release/_includes/site/scripts.html#L3-L4).
+See them in action [here](https://github.com/emma-sax4/emma-sax4.github.io/blob/129867d8135a930f4d364fe026db123d655b5ca8/_includes/site/scripts.html#L3-L4.
 
 ## Conclusion
 


### PR DESCRIPTION
## Changes
Links to GitHub in blog posts should always point to a file at a specific commit, not at the `release` branch. This way if the `release` branch changes the file (which it will certainly do at some point), then the links don't break and aren't inaccurate.