### PR TITLE
Fix broken home page

### DIFF
--- a/_includes/site/header.html
+++ b/_includes/site/header.html
@@ -15,7 +15,7 @@
 
     <div class="collapse navbar-collapse" id="navbar-links">
       <ul class="navbar-nav ml-auto mt-2 mt-md-0">
-        {% assign sorted_pages = site.pages | where_exp: "item", "item.order" | sort: "order" | shift %}
+        {% assign sorted_pages = site.pages | where_exp: "item", "item.order" | sort: "order" %}
 
         {% for node in sorted_pages %}
           {% unless node.autogen == "jekyll-paginate-v2" %}


### PR DESCRIPTION
## Changes
The navbar currently does not have a button to get back to the home page, even though it exists:
![image](https://user-images.githubusercontent.com/7562793/77132381-37c5bd80-6a2d-11ea-873b-f759995e3d01.png)
