### PR TITLE
New version of jekyll feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 # Gems from RubyGems that are required for all environments
 gem 'jekyll',                      '~> 3.8'
 gem 'jekyll-default-layout',       '~> 0.1.4'
+gem 'jekyll-last-modified-at',     '~> 1.2.1'
 gem 'jekyll-mentions',             '~> 1.6.0'
 gem 'jekyll-paginate-v2',          '~> 3.0.0'
 gem 'jekyll-redirect-from',        '~> 0.16.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emma-sax4/jekyll-feed.git
-  revision: 22154a24695acf101dace7202567a1b4396932e4
+  revision: 5238554d9833aec81981454a066cd59e590858a8
   branch: emmasax4_feed
   specs:
     jekyll-feed (0.13.0)
@@ -72,6 +72,9 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-default-layout (0.1.4)
       jekyll (~> 3.0)
+    jekyll-last-modified-at (1.2.1)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
     jekyll-mentions (1.6.0)
       html-pipeline (~> 2.3)
       jekyll (>= 3.7, < 5.0)
@@ -104,6 +107,7 @@ GEM
     parallel (1.19.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.13)
     public_suffix (4.0.3)
     rainbow (3.0.0)
     rb-fsevent (0.10.3)
@@ -132,6 +136,7 @@ DEPENDENCIES
   jekyll (~> 3.8)
   jekyll-default-layout (~> 0.1.4)
   jekyll-feed!
+  jekyll-last-modified-at (~> 1.2.1)
   jekyll-mentions (~> 1.6.0)
   jekyll-paginate-v2 (~> 3.0.0)
   jekyll-redirect-from (~> 0.16.0)

--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,7 @@ exclude:
 plugins:
   - jekyll-default-layout
   - jekyll-feed
+  - jekyll-last-modified-at
   - jekyll-mentions
   - jekyll-paginate-v2
   - jekyll-redirect-from


### PR DESCRIPTION
## Changes
Use this commit (https://github.com/emma-sax4/jekyll-feed/commit/5238554d9833aec81981454a066cd59e590858a8) from `jekyll-feed` so that the `<updated>` part of the `feed.xml` isn't changing all over the place. And then use `jekyll-last-modified-at` so that this code in `jekyll-feed` works.

Changing this because otherwise the feed uses `site.time` which is just the build time.