### PR TITLE
More testing

### DIFF
--- a/.github/workflows/merge_scheduler.yml
+++ b/.github/workflows/merge_scheduler.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: emma-sax4/merge-schedule-action@emmasax4_merge_scheduler
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       run: bundle exec htmlproofer --assume-extension --allow-hash-href --internal-domains /emmasax4.info/ --only_4xx ./_site/
 
     - name: GitHub Pages Deploy
-      uses: JamesIves/github-pages-deploy-action@releases/v3
+      uses: emma-sax4/github-pages-deploy-action@emmasax4_github_pages_deploy_action
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: master


### PR DESCRIPTION
## Changes
* Use my fork of the github pages deployer. There's more information about why I'm doing this in my commit, but essentially I don't want to depend and use a version of something that's based on a general branch, because branches get pushed to often. If it was a real GH release or something, then that release version content wouldn't change.
* Test out using the GH token once more for the auto-merger instead of using my personal access token.

## Merge Scheduler
> If you'd like to use the merge scheduler GitHub Action, when you're ready to merge, then add a comment to the bottom of this description where the date/time is written in UTC and the pull request will merged and deployed within the next 5–10 minutes after the time provided. The comment should look like this:
>
> /schedule YYYY-MM-DD HH:MM:SS

/schedule 2020-05-15 20:15:00