### PR TITLE
Test auto-merging when there's two workflows

### DIFF
--- a/.github/workflows/merge_scheduler.yml
+++ b/.github/workflows/merge_scheduler.yml
@@ -1,7 +1,7 @@
 name: Pull Request Merge Scheduler
 on:
   pull_request:
-    types: [created, edited]
+    types: [opened, edited]
 
 jobs:
   merge-scheduler:

--- a/README.md
+++ b/README.md
@@ -11,5 +11,3 @@ For information on licensing, please see [LICENSE](https://github.com/emma-sax4/
 This repository does have a standard [Code of Conduct](https://github.com/emma-sax4/emma-sax4.github.io/blob/source/.github/code_of_conduct.md).
 
 This website was originally generated using the [Cayman theme](https://github.com/jasonlong/cayman-theme) by [Jason Long](https://twitter.com/jasonlong).
-
-<!-- Adding a comment - for testing purposes. -->


### PR DESCRIPTION
## Changes
* Remove the comment

The reason for this test _again_ is to see if we can get a happy medium when there's two workflows. One of the workflows runs on a cron to do the merging, and provides a personal access token. The other workflow runs when PRs are updated/created and provides the github token, in order to correctly make the check.

## Merge Scheduler
> If you'd like to use the merge scheduler GitHub Action, when you're ready to merge, then add a comment to the bottom of this description where the date/time is written in UTC and the pull request will merged and deployed within the next 5–10 minutes after the time provided. The comment should look like this:
> ```
> /schedule YYYY-MM-DD HH:MM:SS
> ```
/schedule 2020-05-16 20:41:00