### PR TITLE
Rename Slack Notifier action

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Notify Slack on Success
       if: success()
-      uses: emma-sax4/action-slacker@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:
@@ -56,7 +56,7 @@ jobs:
 
     - name: Notify Slack on Failure
       if: failure()
-      uses: emma-sax4/action-slacker@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Notify Slack on Success
       if: success()
-      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_slack_notifier_action
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:
@@ -56,7 +56,7 @@ jobs:
 
     - name: Notify Slack on Failure
       if: failure()
-      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_slack_notifier_action
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Notify Slack on Success
       if: success()
-      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_slack_notifier_action
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:
@@ -61,7 +61,7 @@ jobs:
 
     - name: Notify Slack on Failure
       if: failure()
-      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_slack_notifier_action
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Notify Slack on Success
       if: success()
-      uses: emma-sax4/action-slacker@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:
@@ -61,7 +61,7 @@ jobs:
 
     - name: Notify Slack on Failure
       if: failure()
-      uses: emma-sax4/action-slacker@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Notify Slack on Success
       if: success()
-      uses: emma-sax4/action-slacker@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:
@@ -79,7 +79,7 @@ jobs:
 
     - name: Notify Slack on Failure
       if: failure()
-      uses: emma-sax4/action-slacker@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Notify Slack on Success
       if: success()
-      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_slack_notifier_action
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:
@@ -79,7 +79,7 @@ jobs:
 
     - name: Notify Slack on Failure
       if: failure()
-      uses: emma-sax4/slack-notifier-action@emmasax4_action_slacker
+      uses: emma-sax4/slack-notifier-action@emmasax4_slack_notifier_action
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:


### PR DESCRIPTION
## Changes
I renamed the `action-slacker` to be `slack-notifier-action` so that the world "action" was at the end, so now we need to call the "new" action in our workflow files

## Merge Schedule
/schedule 2020-05-18 01:33:00