### PR TITLE
Update versions of gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,15 +2,15 @@ source "https://rubygems.org"
 
 # Gems from RubyGems that are required for all environments
 gem 'jekyll',                      '~> 3.8'
-gem 'jekyll-default-layout',       '~> 0.1.4'
-gem 'jekyll-last-modified-at',     '~> 1.2.1'
-gem 'jekyll-mentions',             '~> 1.6.0'
-gem 'jekyll-paginate-v2',          '~> 3.0.0'
-gem 'jekyll-redirect-from',        '~> 0.16.0'
-gem 'jekyll-relative-links',       '~> 0.6.1'
-gem 'jekyll-time-to-read',         '~> 0.1.2'
-gem 'jekyll-titles-from-headings', '~> 0.5.3'
-gem 'rouge',                       '~> 3.17'
+gem 'jekyll-default-layout',       '~> 0.1'
+gem 'jekyll-last-modified-at',     '~> 1.3'
+gem 'jekyll-mentions',             '~> 1.6'
+gem 'jekyll-paginate-v2',          '~> 3.0'
+gem 'jekyll-redirect-from',        '~> 0.16'
+gem 'jekyll-relative-links',       '~> 0.6'
+gem 'jekyll-time-to-read',         '~> 0.1'
+gem 'jekyll-titles-from-headings', '~> 0.5'
+gem 'rouge',                       '~> 3.19'
 
 # Gems from GitHub that are required for all environments
 gem 'jekyll-feed',    git: 'https://github.com/emma-sax4/jekyll-feed.git',    branch: 'emmasax4_feed'
@@ -19,5 +19,5 @@ gem 'jekyll-sitemap', git: 'https://github.com/emma-sax4/jekyll-sitemap.git', br
 
 # Gems for only test/development environment
 group :test, :development do
-  gem 'html-proofer', '~> 3.15.1'
+  gem 'html-proofer', '~> 3.15'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/emma-sax4/jekyll-seo-tag.git
-  revision: 073b9d922771cc728af9e9a4007091d5b45fffec
+  revision: eeea1ee1d815d71575523d8293ef10b46eaa98ed
   branch: emmasax4_seo_tag
   specs:
     jekyll-seo-tag (2.6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emma-sax4/jekyll-feed.git
-  revision: 281a53ed7f501c8ced42317e1a1734ee57607596
+  revision: 6a6c0e1d2d7b194678a233db9befca6d05ee7460
   branch: emmasax4_feed
   specs:
     jekyll-feed (0.13.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/emma-sax4/jekyll-seo-tag.git
-  revision: 8b053787794ab482089b40d6befa4597c9da65b9
+  revision: 073b9d922771cc728af9e9a4007091d5b45fffec
   branch: emmasax4_seo_tag
   specs:
     jekyll-seo-tag (2.6.1)
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/emma-sax4/jekyll-sitemap.git
-  revision: b0c3e93d0bd65aa08e2e3109bdeedac25a8f62b8
+  revision: 8a439724c14e8a354ac711d3b7454b8d8655056a
   branch: emmasax4_sitemap
   specs:
     jekyll-sitemap (1.4.0)
@@ -43,10 +43,10 @@ GEM
     eventmachine (1.2.7)
     ffi (1.12.2)
     forwardable-extended (2.6.0)
-    html-pipeline (2.12.3)
+    html-pipeline (2.13.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    html-proofer (3.15.1)
+    html-proofer (3.15.3)
       addressable (~> 2.3)
       mercenary (~> 0.3)
       nokogumbo (~> 2.0)
@@ -72,7 +72,7 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-default-layout (0.1.4)
       jekyll (~> 3.0)
-    jekyll-last-modified-at (1.2.1)
+    jekyll-last-modified-at (1.3.0)
       jekyll (>= 3.7, < 5.0)
       posix-spawn (~> 0.3.9)
     jekyll-mentions (1.6.0)
@@ -107,7 +107,7 @@ GEM
     parallel (1.19.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    posix-spawn (0.3.13)
+    posix-spawn (0.3.14)
     public_suffix (4.0.5)
     rainbow (3.0.0)
     rb-fsevent (0.10.4)
@@ -121,7 +121,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     thread_safe (0.3.6)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
@@ -132,20 +132,20 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer (~> 3.15.1)
+  html-proofer (~> 3.15)
   jekyll (~> 3.8)
-  jekyll-default-layout (~> 0.1.4)
+  jekyll-default-layout (~> 0.1)
   jekyll-feed!
-  jekyll-last-modified-at (~> 1.2.1)
-  jekyll-mentions (~> 1.6.0)
-  jekyll-paginate-v2 (~> 3.0.0)
-  jekyll-redirect-from (~> 0.16.0)
-  jekyll-relative-links (~> 0.6.1)
+  jekyll-last-modified-at (~> 1.3)
+  jekyll-mentions (~> 1.6)
+  jekyll-paginate-v2 (~> 3.0)
+  jekyll-redirect-from (~> 0.16)
+  jekyll-relative-links (~> 0.6)
   jekyll-seo-tag!
   jekyll-sitemap!
-  jekyll-time-to-read (~> 0.1.2)
-  jekyll-titles-from-headings (~> 0.5.3)
-  rouge (~> 3.17)
+  jekyll-time-to-read (~> 0.1)
+  jekyll-titles-from-headings (~> 0.5)
+  rouge (~> 3.19)
 
 BUNDLED WITH
    2.1.4

--- a/_blog_posts/why-tomorrow-isnt-useful.md
+++ b/_blog_posts/why-tomorrow-isnt-useful.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Why “Tomorrow” Isn't Useful
+title: Why “Tomorrow” Isn’t Useful
 tags: [ self-improvement ]
 permalink: /blog/posts/why-tomorrow-isnt-useful/
 date: 2020-03-04 23:20:00 -0600


### PR DESCRIPTION
## Changes
`bundle update` in order to update versions of gems that are compatible. This pull requests closes https://github.com/emma-sax4/emma-sax4.github.io/issues/224.

Also check for updates on CSS/JS dependencies, and GitHub Actions.